### PR TITLE
fix(wrap): Extensions `functions.handler` -> `eventType` key exists but is `undefined` value

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -111,7 +111,7 @@ export function wrap<T>(cloudFunction: CloudFunction<T>): WrappedFunction {
           params: {},
       };
 
-      if (has(defaultContext, 'eventType') &&
+      if (has(defaultContext, 'eventType') && defaultContext.eventType != undefined &&
         defaultContext.eventType.match(/firebase.database/)) {
         defaultContext.authType = 'UNAUTHENTICATED';
         defaultContext.auth = null;


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. 
We've hooked up this repo with continuous integration to double check those things for you. 

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Description

I've been working on adding tests to [firebase/extensions](https://github.com/firebase/extensions) and when trying to wrap the function handlers used by Extensions (e.g. `functions.handler.firestore.document.onWrite`) it errors with `TypeError: Cannot read property 'match' of undefined` as the `eventType` key 'does' exist on the `defaultContext` object, but has an `undefined` value assigned.

This small PR adds an additional `undefined` check.

```js
export const fstranslate = functions.handler.firestore.document.onWrite(
  async (change): Promise<void> => {
  console.warn('Hello from inside my wrapped handler function.');
  return;
});

// ...
import * as functionsTestInit from "firebase-functions-test";
// ...
let functionsTest = functionsTestInit();
// ...


const wrappedFn = functionsTest.wrap(exportedFns.fstranslate);
const before = functionsTest.firestore.makeDocumentSnapshot({}, "foo/id1");
const after = functionsTest.firestore.makeDocumentSnapshot({ input: "hello" }, "foo/id1");
const change = functionsTest.makeChange(before, after);

wrappedFn(change); // Errors
```


**Before**:
![image](https://user-images.githubusercontent.com/5347038/67393764-e9ee7b80-f59a-11e9-85a5-e1048739367a.png)

**After**:
![image](https://user-images.githubusercontent.com/5347038/67394077-8153ce80-f59b-11e9-8efe-33bd8d4af25f.png)


### Code sample

N/A
